### PR TITLE
http-repository-blocked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.tm.kafka</groupId>
@@ -13,8 +13,8 @@
   <properties>
     <kafka.version>2.0.1</kafka.version>
     <jackson.version>2.12.1</jackson.version>
-    <confluent.version>5.0.1</confluent.version>
-    <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+    <confluent.version>5.1.0</confluent.version>
+    <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Problem

[ERROR] Failed to execute goal on project kafka-connect-aws-lambda: Could not resolve dependencies for project com.tm.kafka:kafka-connect-aws-lambda:jar:1.0: Failed to collect dependencies at io.confluent:kafka-connect-avro-converter:jar:5.1.0: Failed to read artifact descriptor for io.confluent:kafka-connect-avro-converter:jar:5.1.0: Could not transfer artifact io.confluent:kafka-connect-avro-converter:pom:5.1.0 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [confluent (http://packages.confluent.io/maven/, default, releases+snapshots)] -> [Help 1]

## Cause

The latest versions of Maven (3.8.1+) are blocking non HTTPS connections. So if an application pom.xml refers to a repository using HTTP instead of HTTPS it can get blocked with the error as seen above and the build will fail.

## Solution
Upgrade the Maven repository so that it uses an HTTPS repository URL instead of the obsolete HTTP one.

## More context
https://help.mulesoft.com/s/article/Maven-error-when-building-application-Blocked-Mirror-for-repositories